### PR TITLE
Added a shorthand equivalent alias for individual commands

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -46,6 +46,8 @@ e.g. typing *`help`* and pressing kbd:[Enter] will open the help window.
 ====
 *Command Format*
 
+* Some commands have an alias, which you can also use to execute the command e.g. to add a person to the address book, you can type either `add n/John Doe` or `a n/John Doe`.
+
 * Words in `UPPER_CASE` are the parameters to be supplied by the user e.g. in `add n/NAME`, `NAME` is a parameter which can be used as `add n/John Doe`.
 * Items in square brackets are optional e.g `n/NAME [t/TAG]` can be used as `n/John Doe t/friend` or as `n/John Doe`.
 * Items with `…`​ after them can be used multiple times including zero times e.g. `[t/TAG]...` can be used as `{nbsp}` (i.e. 0 times), `t/friend`, `t/friend t/family` etc.
@@ -59,6 +61,7 @@ Format: `help`
 === Adding a patient: `add`
 
 Adds a patient to the address book +
+Alias: `a` +
 Format: `add n/NAME ic/IC_NUMBER p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]...`
 
 [TIP]
@@ -72,11 +75,13 @@ Examples:
 === Listing all patients : `list`
 
 Shows a list of all patients in the address book. +
+Alias: `l` +
 Format: `list`
 
 === Editing a patient : `edit`
 
 Edits an existing patient in the address book. +
+Alias: `e` +
 Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]...`
 
 ****
@@ -97,6 +102,7 @@ Edits the name of the 2nd patient to be `Betsy Crower` and clears all existing t
 === Locating patients by name: `find`
 
 Finds patients whose names contain any of the given keywords. +
+Alias: `f` +
 Format: `find KEYWORD [MORE_KEYWORDS]`
 
 ****
@@ -117,6 +123,7 @@ Returns any patient having names `Betsy`, `Tim`, or `John`
 === Deleting a patient : `delete`
 
 Deletes the specified patient from the address book. +
+Alias: `d` +
 Format: `delete INDEX`
 
 ****
@@ -137,6 +144,7 @@ Deletes the 1st patient in the results of the `find` command.
 === Selecting a patient : `select`
 
 Selects the patient identified by the index number used in the displayed patient list. +
+Alias: `s` +
 Format: `select INDEX`
 
 ****
@@ -169,6 +177,7 @@ Generates a MC for the IC number.
 === Generate Receipt : `receipt`
 
 Generates a receipt for the patient’s current visit based on Index Number in the Done List or IC Number. +
+Alias: `rct` +
 Format: `receipt <INDEX>` or `receipt <IC Number>`
 
 Examples:
@@ -181,6 +190,7 @@ Generates a receipt for the patient with that IC number.
 === Generate Referral Letter : `refer`
 
 Create a Referral Letter for the patient based on the IC Number or Index Number from the last list/find command. +
+Alias: `ref` +
 Format: `refer <INDEX> h/<HOSPITAL> d/<DEPARTMENT> r/<REASON> n/<NOTES>` or `refer <IC Number> h/<HOSPITAL> d/<DEPARTMENT> r/<REASON> n/<NOTES>`
 
 Examples:
@@ -193,6 +203,7 @@ Generates a referral letter for the patient of that IC number with the following
 === Add medical records of a patient : `addMedicalRecord`
 
 Add a medical record for the patient based on the Index Number or IC Number from the last list/find command using any/all of the parameters. +
+Alias: `aMR` +
 Format: `addMedicalRecord <INDEX> <RELEVANT PARAMETERS>` or `addMedicalRecord <IC Number> <RELEVANT PARAMETERS>`
 
 Examples:
@@ -205,6 +216,7 @@ Adds blood type of the patient with that IC Number.
 === Adding extra notes to medical records : `addNoteToMedicalRecord`
 
 Add a note to the current medical record of a specified patient. Patient index is referenced from the previous ‘list’ or ‘find’ command. +
+Alias: `aNMR` +
 Format: `addNoteToMedicalRecord <INDEX> m/<MESSAGE>` or `addNoteToMedicalRecord <IC Number> m/<MESSAGE>`
 
 Examples:
@@ -217,6 +229,7 @@ Adds the message to the patient with that IC number.
 === Add a new medicine to records : `addMedicine`
 
 Adds a new medicine into a record. +
+Alias: `aM` +
 Format: `addMedicine sn/<SERIAL NUMBER> n/<NAME> s/<CURRENT STOCK> p/<PRICE PER PIECE> min/<MINIMUM STOCK QUANTITY>`
 
 Example:
@@ -227,11 +240,13 @@ Adds a new Medicine called panadol with serial number 1000, stock of 500 units, 
 === List all medicine in stock : `listStock`
 
 List all medical stocks in the clinic. +
+Alias: `lS` +
 Format: `listStock`
 
 === Finding medicine details : `findStock`
 
 Find the details of a given medicine from the serial number.
+Alias: `fS` +
 Format: `findStock <SERIAL NUMBER>`
 
 Example:
@@ -243,11 +258,13 @@ Finds the details of the medicine tagged with the serial number 1001.
 === Check the stocks of all medicine that are low in supply : `checkStock`
 
 List all medicines that are low in stock. +
+Alias: `cS` +
 Format: `checkStock`
 
 === Register Patient to Queue : `register`
 
 Register a new patient that comes to the clinic. +
+Alias: `reg` +
 Format: `register <INDEX>`
 
 Example:
@@ -258,11 +275,13 @@ Register the patient into the 3rd index.
 === Serve the first patient in the queue : `serve`
 
 Serve the patient first in queue. +
+Alias: `ser` +
 Format: `serve`
 
 === Remove a patient from queue : `dequeue`
 
 Remove someone from the queue if he/she leaves before being served. +
+Alias: `deq` +
 Format: `dequeue <INDEX>` or `dequeue <IC Number>`
 
 Examples:
@@ -275,6 +294,7 @@ Dequeues the patient with that IC Number.
 === Insert a patient to queue : `insert`
 
 Insert a patient at specified position in the queue. +
+Alias: `i` +
 Format: `insert <INDEX> <POSITION>` or `insert <IC Number> <POSITION>`
 
 Examples:
@@ -288,6 +308,7 @@ Inserts the patient with that IC number to the 5th index of the queue.
 === Listing entered commands : `history`
 
 Lists all the commands that you have entered in reverse chronological order. +
+Alias: `h` +
 Format: `history`
 
 [NOTE]
@@ -299,6 +320,7 @@ Pressing the kbd:[&uarr;] and kbd:[&darr;] arrows will display the previous and 
 === Undoing previous command : `undo`
 
 Restores the address book to the state before the previous _undoable_ command was executed. +
+Alias: `u` +
 Format: `undo`
 
 [NOTE]
@@ -325,6 +347,7 @@ The `undo` command fails as there are no undoable commands executed previously.
 === Redoing the previously undone command : `redo`
 
 Reverses the most recent `undo` command. +
+Alias: `r` +
 Format: `redo`
 
 Examples:
@@ -348,6 +371,7 @@ The `redo` command fails as there are no `undo` commands executed previously.
 === Clearing all entries : `deleteAll`
 
 Clears all entries from the address book. +
+Alias: `dA` +
 Format: `deleteAll`
 
 === Exiting the program : `exit`

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -19,6 +19,7 @@ import seedu.address.model.person.Patient;
 public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
+    public static final String COMMAND_ALIAS = "a";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a patient to the address book. "
             + "Parameters: "

--- a/src/main/java/seedu/address/logic/commands/AddMedicalRecordCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMedicalRecordCommand.java
@@ -23,6 +23,7 @@ import seedu.address.model.person.medicalrecord.MedicalRecord;
 public class AddMedicalRecordCommand extends Command {
 
     public static final String COMMAND_WORD = "addMedicalRecord";
+    public static final String COMMAND_ALIAS = "aMR";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Creates a new medical record, or adds data to existing "

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -17,6 +17,7 @@ import seedu.address.model.person.Patient;
 public class DeleteCommand extends Command {
 
     public static final String COMMAND_WORD = "delete";
+    public static final String COMMAND_ALIAS = "d";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the patient identified by the index number used in the displayed patient list.\n"

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -35,6 +35,7 @@ import seedu.address.model.tag.Tag;
 public class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
+    public static final String COMMAND_ALIAS = "e";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the patient identified "
             + "by the index number used in the displayed patient list. "

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -14,6 +14,7 @@ import seedu.address.model.person.NameContainsKeywordsPredicate;
 public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
+    public static final String COMMAND_ALIAS = "f";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"

--- a/src/main/java/seedu/address/logic/commands/HistoryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HistoryCommand.java
@@ -14,6 +14,7 @@ import seedu.address.model.Model;
 public class HistoryCommand extends Command {
 
     public static final String COMMAND_WORD = "history";
+    public static final String COMMAND_ALIAS = "h";
     public static final String MESSAGE_SUCCESS = "Entered commands (from most recent to earliest):\n%1$s";
     public static final String MESSAGE_NO_HISTORY = "You have not yet entered any commands.";
 

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -12,6 +12,7 @@ import seedu.address.model.Model;
 public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
+    public static final String COMMAND_ALIAS = "l";
 
     public static final String MESSAGE_SUCCESS = "Listed all persons";
 

--- a/src/main/java/seedu/address/logic/commands/ReceiptCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ReceiptCommand.java
@@ -19,6 +19,7 @@ import seedu.address.model.person.Patient;
  */
 public class ReceiptCommand extends Command {
     public static final String COMMAND_WORD = "receipt";
+    public static final String COMMAND_ALIAS = "rct";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Generates a receipt for the patient in the specified"
             + " index. Includes information like the date of visit, consultation fee, medicine sold etc. \n"

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -13,6 +13,8 @@ import seedu.address.model.Model;
 public class RedoCommand extends Command {
 
     public static final String COMMAND_WORD = "redo";
+    public static final String COMMAND_ALIAS = "r";
+
     public static final String MESSAGE_SUCCESS = "Redo success!";
     public static final String MESSAGE_FAILURE = "No more commands to redo!";
 

--- a/src/main/java/seedu/address/logic/commands/SelectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SelectCommand.java
@@ -19,6 +19,7 @@ import seedu.address.model.person.Patient;
 public class SelectCommand extends Command {
 
     public static final String COMMAND_WORD = "select";
+    public static final String COMMAND_ALIAS = "s";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Selects the patient identified by the index number used in the displayed patient list.\n"

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -13,6 +13,8 @@ import seedu.address.model.Model;
 public class UndoCommand extends Command {
 
     public static final String COMMAND_WORD = "undo";
+    public static final String COMMAND_ALIAS = "u";
+
     public static final String MESSAGE_SUCCESS = "Undo success!";
     public static final String MESSAGE_FAILURE = "No more commands to undo!";
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -51,27 +51,34 @@ public class AddressBookParser {
         switch (commandWord) {
 
         case AddCommand.COMMAND_WORD:
+        case AddCommand.COMMAND_ALIAS:
             return new AddCommandParser().parse(arguments);
 
         case EditCommand.COMMAND_WORD:
+        case EditCommand.COMMAND_ALIAS:
             return new EditCommandParser().parse(arguments);
 
         case SelectCommand.COMMAND_WORD:
+        case SelectCommand.COMMAND_ALIAS:
             return new SelectCommandParser().parse(arguments);
 
         case DeleteCommand.COMMAND_WORD:
+        case DeleteCommand.COMMAND_ALIAS:
             return new DeleteCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();
 
         case FindCommand.COMMAND_WORD:
+        case FindCommand.COMMAND_ALIAS:
             return new FindCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
+        case ListCommand.COMMAND_ALIAS:
             return new ListCommand();
 
         case HistoryCommand.COMMAND_WORD:
+        case HistoryCommand.COMMAND_ALIAS:
             return new HistoryCommand();
 
         case ExitCommand.COMMAND_WORD:
@@ -81,15 +88,19 @@ public class AddressBookParser {
             return new HelpCommand();
 
         case UndoCommand.COMMAND_WORD:
+        case UndoCommand.COMMAND_ALIAS:
             return new UndoCommand();
 
         case RedoCommand.COMMAND_WORD:
+        case RedoCommand.COMMAND_ALIAS:
             return new RedoCommand();
 
         case AddMedicalRecordCommand.COMMAND_WORD:
+        case AddMedicalRecordCommand.COMMAND_ALIAS:
             return new AddMedicalRecordCommandParser().parse(arguments);
 
         case ReceiptCommand.COMMAND_WORD:
+        case ReceiptCommand.COMMAND_ALIAS:
             return new ReceiptCommandParser().parse(arguments);
 
         default:

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -49,6 +49,14 @@ public class AddressBookParserTest {
     }
 
     @Test
+    public void parseCommand_addAlias() throws Exception {
+        Patient patient = new PersonBuilder().build();
+        AddCommand command = (AddCommand) parser.parseCommand(AddCommand.COMMAND_ALIAS + " "
+                + PersonUtil.getPersonDetails(patient));
+        assertEquals(new AddCommand(patient), command);
+    }
+
+    @Test
     public void parseCommand_clear() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
@@ -62,10 +70,26 @@ public class AddressBookParserTest {
     }
 
     @Test
+    public void parseCommand_deleteAlias() throws Exception {
+        DeleteCommand command = (DeleteCommand) parser.parseCommand(
+                DeleteCommand.COMMAND_ALIAS + " " + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+    }
+
+    @Test
     public void parseCommand_edit() throws Exception {
         Patient patient = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(patient).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
+                + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
+        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
+    }
+
+    @Test
+    public void parseCommand_editAlias() throws Exception {
+        Patient patient = new PersonBuilder().build();
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(patient).build();
+        EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_ALIAS + " "
                 + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
         assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
     }
@@ -81,6 +105,14 @@ public class AddressBookParserTest {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+    }
+
+    @Test
+    public void parseCommand_findAlias() throws Exception {
+        List<String> keywords = Arrays.asList("foo", "bar", "baz");
+        FindCommand command = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_ALIAS + " " + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
     }
 
@@ -104,15 +136,41 @@ public class AddressBookParserTest {
     }
 
     @Test
+    public void parseCommand_historyAlias() throws Exception {
+        assertTrue(parser.parseCommand(HistoryCommand.COMMAND_ALIAS) instanceof HistoryCommand);
+        assertTrue(parser.parseCommand(HistoryCommand.COMMAND_ALIAS + " 3") instanceof HistoryCommand);
+
+        try {
+            parser.parseCommand("histories");
+            throw new AssertionError("The expected ParseException was not thrown.");
+        } catch (ParseException pe) {
+            assertEquals(MESSAGE_UNKNOWN_COMMAND, pe.getMessage());
+        }
+    }
+
+    @Test
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
     }
 
     @Test
+    public void parseCommand_listAlias() throws Exception {
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_ALIAS) instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_ALIAS + " 3") instanceof ListCommand);
+    }
+
+    @Test
     public void parseCommand_receipt() throws Exception {
         ReceiptCommand command = (ReceiptCommand) parser.parseCommand(
                 ReceiptCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new ReceiptCommand(INDEX_FIRST_PERSON), command);
+    }
+
+    @Test
+    public void parseCommand_receiptAlias() throws Exception {
+        ReceiptCommand command = (ReceiptCommand) parser.parseCommand(
+                ReceiptCommand.COMMAND_ALIAS + " " + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new ReceiptCommand(INDEX_FIRST_PERSON), command);
     }
 
@@ -124,15 +182,34 @@ public class AddressBookParserTest {
     }
 
     @Test
+    public void parseCommand_selectAlias() throws Exception {
+        SelectCommand command = (SelectCommand) parser.parseCommand(
+                SelectCommand.COMMAND_ALIAS + " " + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new SelectCommand(INDEX_FIRST_PERSON), command);
+    }
+
+    @Test
     public void parseCommand_redoCommandWord_returnsRedoCommand() throws Exception {
         assertTrue(parser.parseCommand(RedoCommand.COMMAND_WORD) instanceof RedoCommand);
         assertTrue(parser.parseCommand("redo 1") instanceof RedoCommand);
     }
 
     @Test
+    public void parseCommand_redoCommandAlias_returnsRedoCommand() throws Exception {
+        assertTrue(parser.parseCommand(RedoCommand.COMMAND_ALIAS) instanceof RedoCommand);
+        assertTrue(parser.parseCommand(RedoCommand.COMMAND_ALIAS + " 1") instanceof RedoCommand);
+    }
+
+    @Test
     public void parseCommand_undoCommandWord_returnsUndoCommand() throws Exception {
         assertTrue(parser.parseCommand(UndoCommand.COMMAND_WORD) instanceof UndoCommand);
         assertTrue(parser.parseCommand("undo 3") instanceof UndoCommand);
+    }
+
+    @Test
+    public void parseCommand_undoCommandAlias_returnsUndoCommand() throws Exception {
+        assertTrue(parser.parseCommand(UndoCommand.COMMAND_ALIAS) instanceof UndoCommand);
+        assertTrue(parser.parseCommand(UndoCommand.COMMAND_ALIAS + " 3") instanceof UndoCommand);
     }
 
     @Test


### PR DESCRIPTION
For the following commands:

=== Adding a patient: `add`
Alias: `a`

=== Listing all patients : `list`
Alias: `l`

=== Editing a patient : `edit`
Alias: `e`

=== Locating patients by name: `find`
Alias: `f`

=== Deleting a patient : `delete`
Alias: `d`

=== Selecting a patient : `select`
Alias: `s`

=== Generate Receipt : `receipt`
Alias: `rct`

=== Generate Referral Letter : `refer`
Alias: `ref`

=== Add medical records of a patient : `addMedicalRecord`
Alias: `aMR`

=== Adding extra notes to medical records : `addNoteToMedicalRecord`
Alias: `aNMR`

=== Add a new medicine to records : `addMedicine`
Alias: `aM`

=== List all medicine in stock : `listStock`
Alias: `lS`

=== Finding medicine details : `findStock`
Alias: `fS`

=== Check the stocks of all medicine that are low in supply : `checkStock`
Alias: `cS`

=== Register Patient to Queue : `register`
Alias: `reg`

=== Remove a patient from queue : `dequeue`
Alias: `deq`

=== Insert a patient to queue : `insert`
Alias: `i`

=== Listing entered commands : `history`
Alias: `h`

=== Undoing previous command : `undo`
Alias: `u`

=== Redoing the previously undone command : `redo`
Alias: `r`